### PR TITLE
Added App about call

### DIFF
--- a/mealieapi/client.py
+++ b/mealieapi/client.py
@@ -24,7 +24,7 @@ from mealieapi.users import Group, User, UserSignup
 
 class MealieClient(RawClient):
     # App About
-    async def get_app_info(self) -> DebugVersion:
+    async def get_app_info(self) -> AppVersion:
         data = await self.request("app/about", use_auth=False)
         return AppVersion(**data)
 

--- a/mealieapi/client.py
+++ b/mealieapi/client.py
@@ -23,6 +23,12 @@ from mealieapi.users import Group, User, UserSignup
 
 
 class MealieClient(RawClient):
+    # App About
+    async def get_app_info(self) -> DebugVersion:
+        data = await self.request("app/about", use_auth=False)
+        return DebugVersion(**data)  # type: ignore[arg-type]
+    # endregion
+
     # User API Keys
     def process_token_json(self, data: dict[str, t.Any]) -> Token:
         return Token(self, **data)

--- a/mealieapi/client.py
+++ b/mealieapi/client.py
@@ -8,7 +8,7 @@ from mealieapi.auth import Token
 from mealieapi.backup import Backup
 from mealieapi.const import YEAR_MONTH_DAY, YEAR_MONTH_DAY_HOUR_MINUTE_SECOND
 from mealieapi.meals import Ingredient, Meal, MealPlan, MealPlanDay, ShoppingList
-from mealieapi.misc import DebugInfo, DebugStatistics, DebugVersion, File
+from mealieapi.misc import AppVersion, DebugInfo, DebugStatistics, DebugVersion, File
 from mealieapi.raw import RawClient
 from mealieapi.recipes import (
     Recipe,
@@ -26,8 +26,7 @@ class MealieClient(RawClient):
     # App About
     async def get_app_info(self) -> DebugVersion:
         data = await self.request("app/about", use_auth=False)
-        return DebugVersion(**data)  # type: ignore[arg-type]
-    # endregion
+        return AppVersion(**data)
 
     # User API Keys
     def process_token_json(self, data: dict[str, t.Any]) -> Token:

--- a/mealieapi/misc.py
+++ b/mealieapi/misc.py
@@ -26,6 +26,13 @@ class File(InteractiveModel):
         return await self._client.download_file(self.file_token)
 
 
+class AppVersion(BaseModel):
+    production: bool | None = None
+    version: str | None = None
+    demo_status: bool | None = None
+    allow_signup: bool | None = None
+
+
 class DebugInfo(BaseModel):
     production: bool | None = None
     version: str | None = None

--- a/mealieapi/model.py
+++ b/mealieapi/model.py
@@ -1,5 +1,6 @@
-import typing as t
 import logging
+import typing as t
+
 from pydantic import BaseModel as BM
 from pydantic.error_wrappers import ValidationError
 

--- a/mealieapi/recipes.py
+++ b/mealieapi/recipes.py
@@ -1,5 +1,5 @@
 import typing as t
-from datetime import datetime, date
+from datetime import date, datetime
 from zipfile import ZipFile
 
 import slugify

--- a/poetry.lock
+++ b/poetry.lock
@@ -18,7 +18,7 @@ typing-extensions = {version = ">=3.7.4", markers = "python_version < \"3.8\""}
 yarl = ">=1.0,<2.0"
 
 [package.extras]
-speedups = ["aiodns", "brotli", "cchardet"]
+speedups = ["Brotli", "aiodns", "cchardet"]
 
 [[package]]
 name = "aiosignal"
@@ -67,10 +67,10 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.extras]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit"]
-docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
-tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface"]
-tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins"]
+dev = ["coverage[toml] (>=5.0.2)", "furo", "hypothesis", "mypy", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "six", "sphinx", "sphinx-notfound-page", "zope.interface"]
+docs = ["furo", "sphinx", "sphinx-notfound-page", "zope.interface"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "mypy", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "six", "zope.interface"]
+tests-no-zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "mypy", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "six"]
 
 [[package]]
 name = "black"
@@ -89,7 +89,7 @@ tomli = ">=0.2.6,<2.0.0"
 typed-ast = {version = ">=1.4.2", markers = "python_version < \"3.8\" and implementation_name == \"cpython\""}
 typing-extensions = [
     {version = ">=3.10.0.0", markers = "python_version < \"3.10\""},
-    {version = "!=3.10.0.1", markers = "python_version >= \"3.10\""},
+    {version = ">=3.10.0.0,<3.10.0.1 || >3.10.0.1", markers = "python_version >= \"3.10\""},
 ]
 
 [package.extras]
@@ -108,7 +108,7 @@ optional = false
 python-versions = ">=3.5.0"
 
 [package.extras]
-unicode_backport = ["unicodedata2"]
+unicode-backport = ["unicodedata2"]
 
 [[package]]
 name = "click"
@@ -173,8 +173,8 @@ typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
 zipp = ">=0.5"
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
+docs = ["jaraco.packaging (>=8.2)", "rst.linker (>=1.9)", "sphinx"]
+testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pep517", "pyfakefs", "pytest (>=4.6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-flake8", "pytest-mypy"]
 
 [[package]]
 name = "iniconfig"
@@ -193,10 +193,10 @@ optional = false
 python-versions = ">=3.6.1,<4.0"
 
 [package.extras]
-pipfile_deprecated_finder = ["pipreqs", "requirementslib"]
-requirements_deprecated_finder = ["pipreqs", "pip-api"]
 colors = ["colorama (>=0.4.3,<0.5.0)"]
+pipfile-deprecated-finder = ["pipreqs", "requirementslib"]
 plugins = ["setuptools"]
+requirements-deprecated-finder = ["pip-api", "pipreqs"]
 
 [[package]]
 name = "mccabe"
@@ -268,8 +268,8 @@ optional = false
 python-versions = ">=3.6"
 
 [package.extras]
-test = ["pytest-mock (>=3.6)", "pytest-cov (>=2.7)", "pytest (>=6)", "appdirs (==1.4.4)"]
-docs = ["sphinx-autodoc-typehints (>=1.12)", "proselint (>=0.10.2)", "furo (>=2021.7.5b38)", "Sphinx (>=4)"]
+docs = ["Sphinx (>=4)", "furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx-autodoc-typehints (>=1.12)"]
+test = ["appdirs (==1.4.4)", "pytest (>=6)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)"]
 
 [[package]]
 name = "pluggy"
@@ -283,8 +283,8 @@ python-versions = ">=3.6"
 importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 
 [package.extras]
-testing = ["pytest-benchmark", "pytest"]
-dev = ["tox", "pre-commit"]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "py"
@@ -360,11 +360,11 @@ testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xm
 
 [[package]]
 name = "python-slugify"
-version = "6.1.2"
-description = "A Python slugify application that also handles Unicode"
+version = "4.0.1"
+description = "A Python Slugify application that handles Unicode"
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.dependencies]
 text-unidecode = ">=1.3"
@@ -434,13 +434,13 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)", "jaraco.tidelift (>=1.4)"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.3)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
+docs = ["jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx"]
+testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "97bdd42dc0de0cd306d292a546bcf49d2923cd1c8a630fffac42b923a84e7932"
+content-hash = "86a047d8d95188bbe5aeb2f3b205a5685f170ecb46687990ffb3e5283eb944fd"
 
 [metadata.files]
 aiohttp = [
@@ -825,8 +825,7 @@ pytest = [
     {file = "pytest-6.2.5.tar.gz", hash = "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89"},
 ]
 python-slugify = [
-    {file = "python-slugify-6.1.2.tar.gz", hash = "sha256:272d106cb31ab99b3496ba085e3fea0e9e76dcde967b5e9992500d1f785ce4e1"},
-    {file = "python_slugify-6.1.2-py2.py3-none-any.whl", hash = "sha256:7b2c274c308b62f4269a9ba701aa69a797e9bca41aeee5b3a9e79e36b6656927"},
+    {file = "python-slugify-4.0.1.tar.gz", hash = "sha256:69a517766e00c1268e5bbfc0d010a0a8508de0b18d30ad5a1ff357f8ae724270"},
 ]
 text-unidecode = [
     {file = "text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ packages = [
 python = "^3.7"
 aiohttp = "^3.8.1"
 pydantic = "^1.9.1"
-python-slugify = "^6.1.2"
+python-slugify = "4.0.1"
 
 [tool.poetry.dev-dependencies]
 flake8 = "^4.0.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ packages = [
 python = "^3.7"
 aiohttp = "^3.8.1"
 pydantic = "^1.9.1"
-python-slugify = "4.0.1"
+python-slugify = "^4.0.1"
 
 [tool.poetry.dev-dependencies]
 flake8 = "^4.0.1"


### PR DESCRIPTION
I've added the API call to /app/about, closes #7 
Although the DebugVersion is almost the same data that gets returned, I've created a new model for this one, as the Debug endpoints don't exist anymore in V1, probably best to remove those as well?


Not sure if we need `python-slugify` at the highest version, I had to downgrade it to make the library work with Home Assistant...